### PR TITLE
Fix engine type dropdown in 'Circuit Info & Lap Records' #72

### DIFF
--- a/kartiiing/components/circuit/CircuitInfo.tsx
+++ b/kartiiing/components/circuit/CircuitInfo.tsx
@@ -45,7 +45,6 @@ export default function CircuitInfo({ circuit, race }: Props) {
             <div className="mt-3 pt-4 border-t border-gray-300 dark:border-gray-700">
               <FastestLapsWithDropdown
                 fastestLaps={circuit.circuitFastestLaps}
-                showYears={true}
                 preferredEngineTypes={preferredEngineTypes}
               />
             </div>

--- a/kartiiing/components/circuit/FastestLapsWithDropdown.tsx
+++ b/kartiiing/components/circuit/FastestLapsWithDropdown.tsx
@@ -59,7 +59,8 @@ export default function FastestLapsWithDropdown({
     if (initialEngineType && initialEngineType !== selectedEngineType) {
       setSelectedEngineType(initialEngineType);
     }
-  }, [initialEngineType, selectedEngineType]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialEngineType]);
 
   // Set initial category to the fastest lap when engine type changes
   useEffect(() => {


### PR DESCRIPTION
- Fix useEffect dependency array
- Remove showYears prop as it is not needed