### PR TITLE
Bug: circuits searching #88

### DIFF
--- a/kartiiing/app/circuits/circuits-client.tsx
+++ b/kartiiing/app/circuits/circuits-client.tsx
@@ -40,7 +40,6 @@ export function CircuitsClient({ initialData, coordinates }: Props) {
   const {
     data: displayedCircuits,
     totalCount,
-    hasMore,
     loadingMore,
     sentinelRef,
     replaceData,
@@ -117,7 +116,7 @@ export function CircuitsClient({ initialData, coordinates }: Props) {
             sectionWidth={sectionWidth}
             loadingMore={loadingMore}
           />
-          {hasMore && <div ref={sentinelRef} className="h-4 w-full" />}
+          <div ref={sentinelRef} className="h-2 w-full" />
         </div>
       </div>
 


### PR DESCRIPTION
- fix(circuits): always render infinite scroll sentinel for reliable loads
- Removed unused `hasMore` query field and conditional sentinel rendering. The sentinel is now always rendered (height reduced from `h-4` to `h-2`) so the intersection observer reliably detects when users are near the end of the circuits list, triggering load more requests proactively and preventing missed infinite scroll loads.