### PR TITLE
Load calendar events in chunks with infinite scroll #50

### DIFF
--- a/kartiiing/app/calendar/[year]/calendar-client.tsx
+++ b/kartiiing/app/calendar/[year]/calendar-client.tsx
@@ -1,132 +1,122 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { useSectionWidth } from "@/lib/hooks/useSectionWidth";
-import { isCompactSection } from "@/lib/constants/layout";
-import { useRouter } from "next/navigation";
-import { PageWrapper } from "@/components/shared/PageWrapper";
-import { CalendarHeader } from "@/components/calendar/CalendarHeader";
-import { SearchHeader } from "@/components/calendar/SearchHeader";
+import { LIST_VIEW_BREAKPOINT } from "@/lib/constants/layout";
+import { SearchHeader } from "@/components/shared/SearchHeader";
 import { CalendarActions } from "@/components/calendar/CalendarActions";
 import { RacesGrid } from "@/components/calendar/RacesGrid";
 import { BackToTopBtn } from "@/components/shared/btns/BackToTopBtn";
-import { IRaceEvent, RaceEventSortOptions } from "@kartiiing/shared";
+import {
+  IRaceEvent,
+  RaceEventSortOptions,
+  IPaginatedResponse,
+} from "@kartiiing/shared";
 import { getRaceEvents } from "@/lib/api";
+import { useInfiniteScroll } from "@/lib/hooks/useInfiniteScroll";
 
 type Props = {
-  initialRaces: IRaceEvent[];
+  initialData: IPaginatedResponse<IRaceEvent>;
   year: string;
   initialSort: RaceEventSortOptions;
-  years: (number | string)[];
-  description: string;
-}
+};
 
-export function CalendarClient({
-  initialRaces,
-  year,
-  initialSort,
-  years,
-  description,
-}: Props) {
-  const router = useRouter();
-  const [loading, setLoading] = useState(false);
-  const [races, setRaces] = useState<IRaceEvent[]>(initialRaces);
-  const [selectedYear, setSelectedYear] = useState<number | string>(year);
-  const [sortOrder, setSortOrder] = useState<RaceEventSortOptions>(
+const PAGE_SIZE = 20;
+
+export function CalendarClient({ initialData, year, initialSort }: Props) {
+  const normalizedInitialSort =
     initialSort === RaceEventSortOptions.DESC
       ? RaceEventSortOptions.DESC
-      : RaceEventSortOptions.ASC,
+      : RaceEventSortOptions.ASC;
+  const [loading, setLoading] = useState(false);
+  const [sortOrder, setSortOrder] = useState<RaceEventSortOptions>(
+    normalizedInitialSort,
   );
   const [searchQuery, setSearchQuery] = useState("");
   const { sectionRef, sectionWidth } = useSectionWidth();
 
-  useEffect(() => {
-    setRaces(initialRaces);
-    setSelectedYear(year);
-  }, [initialRaces, year]);
+  const fetchRaces = useCallback(
+    (page: number, limit: number) =>
+      getRaceEvents({
+        year: year === "all" ? undefined : year.toString(),
+        sort: sortOrder,
+        search: searchQuery.trim() || undefined,
+        page,
+        limit,
+      }),
+    [year, sortOrder, searchQuery],
+  );
 
-  // Handle search by calling API with search parameter
+  const {
+    data: displayedRaces,
+    totalCount,
+    hasMore,
+    loadingMore,
+    sentinelRef,
+    reset,
+    replaceData,
+  } = useInfiniteScroll<IRaceEvent>({
+    fetchFn: fetchRaces,
+    initialData,
+    pageSize: PAGE_SIZE,
+    resetDeps: [searchQuery, sortOrder, year],
+  });
+
   useEffect(() => {
-    if (!searchQuery.trim()) {
-      setRaces(initialRaces);
+    if (!searchQuery.trim() && sortOrder === normalizedInitialSort) {
+      reset();
       return;
     }
 
-    const performSearch = async () => {
+    const performFetch = async () => {
       setLoading(true);
       try {
-        const response = await getRaceEvents({
-          year: selectedYear === "all" ? undefined : selectedYear.toString(),
-          sort: sortOrder,
-          search: searchQuery.trim(),
-        });
-        setRaces(response.data);
+        const response = await fetchRaces(1, PAGE_SIZE);
+        replaceData(
+          response.data,
+          response.meta.totalItems,
+          response.meta.hasNextPage,
+        );
       } catch (error) {
-        console.error("Error searching races:", error);
-        setRaces([]);
+        console.error("Error fetching races:", error);
+        replaceData([], 0, false);
       } finally {
         setLoading(false);
       }
     };
 
-    const debounceTimer = setTimeout(performSearch, 300);
+    const debounceTimer = setTimeout(performFetch, 300);
     return () => clearTimeout(debounceTimer);
-  }, [searchQuery, initialRaces, sortOrder, selectedYear]);
-
-  // Handle year change by navigating to new route
-  const handleYearChange = (newYear: string | number) => {
-    const yearString = newYear.toString();
-    if (yearString !== selectedYear.toString()) {
-      setLoading(true);
-      router.push(
-        `/calendar/${yearString}?sort=${
-          sortOrder === RaceEventSortOptions.DESC ? "desc" : "asc"
-        }`,
-      );
-    }
-  };
+  }, [
+    searchQuery,
+    sortOrder,
+    fetchRaces,
+    reset,
+    replaceData,
+    initialData,
+    normalizedInitialSort,
+  ]);
 
   // Handle sort order change by navigating to new URL
-  const handleSortChange = () => {
+  const handleSortChange = useCallback(() => {
     const newSortOrder =
       sortOrder === RaceEventSortOptions.ASC
         ? RaceEventSortOptions.DESC
         : RaceEventSortOptions.ASC;
+
     const sortParam =
       newSortOrder === RaceEventSortOptions.DESC ? "desc" : "asc";
+
     setSortOrder(newSortOrder);
 
     const currentUrl = new URL(window.location.href);
     currentUrl.searchParams.set("sort", sortParam);
-    router.replace(currentUrl.pathname + currentUrl.search);
-  };
-
-  // Fetch races from API when sortOrder changes (but not year, as that's handled by navigation)
-  useEffect(() => {
-    if (
-      sortOrder ===
-      (initialSort === RaceEventSortOptions.DESC
-        ? RaceEventSortOptions.DESC
-        : RaceEventSortOptions.ASC)
-    )
-      return;
-
-    setLoading(true);
-    const fetchRaces = async () => {
-      try {
-        const response = await getRaceEvents({
-          year: selectedYear === "all" ? undefined : selectedYear.toString(),
-          sort: sortOrder,
-        });
-        setRaces(response.data);
-      } catch (error) {
-        console.error("Error loading races:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchRaces();
-  }, [sortOrder, selectedYear, initialSort]);
+    window.history.replaceState(
+      window.history.state,
+      "",
+      currentUrl.pathname + currentUrl.search,
+    );
+  }, [sortOrder]);
 
   // Render calendar actions (view toggle, sort toggle, next race button)
   function renderCalendarActions(small = false) {
@@ -134,43 +124,43 @@ export function CalendarClient({
       <CalendarActions
         sortOrder={sortOrder}
         onSortChange={handleSortChange}
-        races={races}
+        races={displayedRaces}
         small={small}
       />
     );
   }
 
+  const showGridToggle = sectionWidth >= LIST_VIEW_BREAKPOINT;
+  const showSentinel = hasMore && !loading;
+
   return (
     <>
-      <PageWrapper ref={sectionRef}>
-        <CalendarHeader
-          description={description}
-          selectedYear={selectedYear}
-          setSelectedYear={handleYearChange}
-          years={years}
-        />
-
+      <div ref={sectionRef}>
         <div className="flex flex-col md:flex-row gap-2 mb-2 items-center">
           <SearchHeader
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
-            races={races}
+            totalResults={totalCount}
+            placeholder="Search... (e.g. kz2 summer)"
           >
-            {isCompactSection(sectionWidth) && renderCalendarActions(true)}
+            {!showGridToggle && renderCalendarActions(true)}
           </SearchHeader>
 
-          {!isCompactSection(sectionWidth) && renderCalendarActions()}
+          {showGridToggle && renderCalendarActions()}
         </div>
 
         <div className="my-4 py-4 border-t border-dashed">
           <RacesGrid
-            races={races}
+            races={displayedRaces}
             loading={loading}
             sectionWidth={sectionWidth}
-            isAllYearsView={selectedYear === "all"}
+            loadingMore={loadingMore}
+            isAllYearsView={year === "all"}
           />
+
+          {showSentinel && <div ref={sentinelRef} className="h-2 w-full" />}
         </div>
-      </PageWrapper>
+      </div>
 
       <BackToTopBtn />
     </>

--- a/kartiiing/app/calendar/[year]/page.tsx
+++ b/kartiiing/app/calendar/[year]/page.tsx
@@ -4,6 +4,8 @@ import {
   getCalendarMetadata,
 } from "@/lib/api";
 import { CalendarClient } from "./calendar-client";
+import { CalendarHeader } from "@/components/calendar/CalendarHeader";
+import { PageWrapper } from "@/components/shared/PageWrapper";
 import { RaceEventSortOptions } from "@kartiiing/shared";
 import { SITE_URL } from "@/lib/utils";
 
@@ -16,7 +18,7 @@ type Props = {
   searchParams: Promise<{
     sort?: string;
   }>;
-}
+};
 
 /**
  * Generate metadata for the calendar page
@@ -64,6 +66,8 @@ export default async function CalendarPage({ params, searchParams }: Props) {
   const racesRes = await getRaceEvents({
     year: year,
     sort: sortOrder,
+    page: 1,
+    limit: 20,
   });
   const availableYears = await getAvailableYears();
   const years = ["all", ...availableYears] as (string | number)[];
@@ -77,12 +81,17 @@ export default async function CalendarPage({ params, searchParams }: Props) {
   }
 
   return (
-    <CalendarClient
-      initialRaces={racesRes.data}
-      year={year}
-      initialSort={sortOrder}
-      years={years}
-      description={description}
-    />
+    <PageWrapper>
+      <CalendarHeader
+        description={description}
+        selectedYear={year}
+        years={years}
+      />
+      <CalendarClient
+        initialData={racesRes}
+        year={year}
+        initialSort={sortOrder}
+      />
+    </PageWrapper>
   );
 }

--- a/kartiiing/app/circuits/page.tsx
+++ b/kartiiing/app/circuits/page.tsx
@@ -6,8 +6,40 @@ import {
   getCircuitsMetadata,
   getCircuitCoordinates,
 } from "@/lib/api";
+import { SITE_URL } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Generate metadata for the circuits page
+ */
+export async function generateMetadata() {
+  try {
+    const metadata = await getCircuitsMetadata();
+
+    return {
+      title: metadata.title,
+      description: metadata.description,
+      keywords: metadata.keywords,
+      openGraph: {
+        url: `${SITE_URL}/circuits`,
+        type: "website",
+      },
+    };
+  } catch (error) {
+    console.error("Error generating circuits metadata:", error);
+
+    return {
+      title: "Circuits - Kartiiing",
+      description: "Explore our database of karting circuits.",
+      keywords: "karting circuits, go kart tracks, racing circuits",
+      openGraph: {
+        url: `${SITE_URL}/circuits`,
+        type: "website",
+      },
+    };
+  }
+}
 
 export default async function CircuitsPage() {
   const initialData = await getCircuits({ page: 1, limit: 20 });

--- a/kartiiing/components/calendar/CalendarHeader.tsx
+++ b/kartiiing/components/calendar/CalendarHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { PageHeader } from "@/components/shared/PageHeader";
 import {
   Select,
@@ -8,22 +9,29 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { RaceEventSortOptions } from "@kartiiing/shared";
 
 type Props = {
   description: string;
   selectedYear: number | string;
-  setSelectedYear: (year: number | string) => void;
   years: (number | string)[];
 };
 
-export function CalendarHeader({
-  description,
-  selectedYear,
-  setSelectedYear,
-  years,
-}: Props) {
+export function CalendarHeader({ description, selectedYear, years }: Props) {
+  const router = useRouter();
+
   const formatYearDisplay = (year: number | string) => {
     return year === "all" ? "All Years" : year;
+  };
+
+  const handleYearChange = (newYear: string) => {
+    const yearString = newYear.toString();
+    if (yearString === selectedYear.toString()) return;
+
+    const currentUrl = new URL(window.location.href);
+    const sortParam =
+      currentUrl.searchParams.get("sort") || RaceEventSortOptions.ASC;
+    router.push(`/calendar/${yearString}?sort=${sortParam}`);
   };
 
   return (
@@ -33,7 +41,7 @@ export function CalendarHeader({
       headerAction={
         <Select
           value={selectedYear.toString()}
-          onValueChange={(val: string) => setSelectedYear(val)}
+          onValueChange={handleYearChange}
         >
           <SelectTrigger
             className="w-29 h-10.5! cursor-pointer font-semibold text-[1rem]"

--- a/kartiiing/components/calendar/RacesGrid.tsx
+++ b/kartiiing/components/calendar/RacesGrid.tsx
@@ -15,6 +15,7 @@ type Props = {
   races: IRaceEvent[];
   loading: boolean;
   sectionWidth: number;
+  loadingMore?: boolean;
   isAllYearsView?: boolean;
 };
 
@@ -46,6 +47,7 @@ export function RacesGrid({
   races,
   loading,
   sectionWidth,
+  loadingMore = false,
   isAllYearsView = false,
 }: Props) {
   const viewMode = useCalendarStore((state) => state.viewMode);
@@ -87,6 +89,8 @@ export function RacesGrid({
           </div>
         </div>
       ))}
+
+      {loadingMore && <Loader />}
     </div>
   );
 }

--- a/kartiiing/components/calendar/__tests__/CalendarHeader.test.tsx
+++ b/kartiiing/components/calendar/__tests__/CalendarHeader.test.tsx
@@ -2,6 +2,14 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { CalendarHeader } from "../CalendarHeader";
 
+const mockRouterPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
+
 describe("CalendarHeader", () => {
   const years = [2024, 2025, "all"];
 
@@ -10,7 +18,6 @@ describe("CalendarHeader", () => {
       <CalendarHeader
         description="2025 season"
         selectedYear={2025}
-        setSelectedYear={vi.fn()}
         years={years}
       />,
     );
@@ -22,14 +29,7 @@ describe("CalendarHeader", () => {
   });
 
   it("formats 'all' as 'All Years' in the select", () => {
-    render(
-      <CalendarHeader
-        description=""
-        selectedYear="all"
-        setSelectedYear={vi.fn()}
-        years={years}
-      />,
-    );
+    render(<CalendarHeader description="" selectedYear="all" years={years} />);
 
     expect(
       screen.getByRole("combobox", { name: /select year/i }),
@@ -37,14 +37,7 @@ describe("CalendarHeader", () => {
   });
 
   it("renders a select with the given years", () => {
-    render(
-      <CalendarHeader
-        description=""
-        selectedYear={2025}
-        setSelectedYear={vi.fn()}
-        years={years}
-      />,
-    );
+    render(<CalendarHeader description="" selectedYear={2025} years={years} />);
 
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });

--- a/kartiiing/lib/constants/layout.ts
+++ b/kartiiing/lib/constants/layout.ts
@@ -1,7 +1,2 @@
-/** Pixel width below which the section is considered "compact" (matches Tailwind's `md:` breakpoint). */
-export const SECTION_COMPACT_BREAKPOINT = 768;
-
-/** Returns true when the given pixel width is in the compact range. */
-export function isCompactSection(width: number): boolean {
-  return width < SECTION_COMPACT_BREAKPOINT;
-}
+/** Pixel width below which the list view layout is not applied. */
+export const LIST_VIEW_BREAKPOINT = 850;

--- a/kartiiing/lib/hooks/useInfiniteScroll.ts
+++ b/kartiiing/lib/hooks/useInfiniteScroll.ts
@@ -27,7 +27,7 @@ interface UseInfiniteScrollResult<T> {
   hasMore: boolean;
   /** Whether a page fetch is currently in progress. */
   loadingMore: boolean;
-  /** Ref to attach to a sentinel element at the bottom of the list. */
+  /** Ref object to attach to a sentinel element at the bottom of the list. */
   sentinelRef: React.RefObject<HTMLDivElement | null>;
   /** Reset to the initial state (e.g. after search or filter change). */
   reset: () => void;
@@ -51,6 +51,10 @@ export function useInfiniteScroll<T>({
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(initialData.meta.hasNextPage);
   const [loadingMore, setLoadingMore] = useState(false);
+  // Counter incremented on every data replacement to force observer re-attachment.
+  // Fixes the case where a search re-renders the sentinel DOM node but hasMore
+  // stays true, so the observer never re-wires to the new element.
+  const [sentinelKey, setSentinelKey] = useState(0);
 
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   // Track the current page so the observer closure always has the latest value
@@ -69,17 +73,23 @@ export function useInfiniteScroll<T>({
   const pageSizeRef = useRef(pageSize);
   pageSizeRef.current = pageSize;
 
-  // Reset to initial state whenever resetDeps change
+  // Callback to revert to the initial server-rendered data.
+  // Re-created whenever resetDeps change; the consumer must call it
+  // explicitly (e.g. in a useEffect when all filters are cleared).
   const reset = useCallback(() => {
     setData(initialData.data);
     setTotalCount(initialData.meta.totalItems);
     setPage(1);
     setHasMore(initialData.meta.hasNextPage);
     setLoadingMore(false);
+    setSentinelKey((prev) => prev + 1);
     // resetDeps intentionally controls when reset re-creates; adding initialData would break the pattern
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, resetDeps);
 
+  // Replace accumulated data with fresh results from a client-side
+  // search or filter. Call this in a useEffect when search/sort changes
+  // to swap in new data while preserving infinite scroll for subsequent pages.
   const replaceData = useCallback(
     (newData: T[], total: number, hasMorePages: boolean) => {
       setData(newData);
@@ -87,19 +97,25 @@ export function useInfiniteScroll<T>({
       setPage(1);
       setHasMore(hasMorePages);
       setLoadingMore(false);
+      setSentinelKey((prev) => prev + 1);
     },
     [],
   );
 
-  // Infinite scroll: load more when sentinel enters viewport
+  // Infinite scroll: load more when sentinel enters viewport.
+  // Depends on hasMore (to disconnect when no more pages) and sentinelKey
+  // (to re-attach after data replacement even when hasMore stays true).
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+
         if (
-          entries[0].isIntersecting &&
+          entry.isIntersecting &&
           hasMoreRef.current &&
           !loadingMoreRef.current
         ) {
@@ -129,7 +145,7 @@ export function useInfiniteScroll<T>({
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, []); // Only mount observer once; refs keep it up-to-date
+  }, [hasMore, sentinelKey]);
 
   return {
     data,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6123,13 +6123,6 @@
         "node": "*"
       }
     },
-    "api/node_modules/minimist": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "api/node_modules/minipass": {
       "version": "7.1.2",
       "license": "ISC",
@@ -8769,11 +8762,13 @@
         "date-fns": "^4.1.0",
         "framer-motion": "^12.19.2",
         "lucide-react": "^0.479.0",
+        "mapbox-gl": "^3.24.1",
         "masonic": "^4.1.0",
         "next": "^16.1.1",
         "next-themes": "^0.4.6",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-map-gl": "^8.1.1",
         "react-world-flags": "^1.6.0",
         "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7",
@@ -8785,6 +8780,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/mapbox-gl": "^3.4.1",
         "@types/node": "^20.17.57",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -12367,14 +12363,6 @@
         "node": "*"
       }
     },
-    "kartiiing/node_modules/minimist": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "kartiiing/node_modules/motion-dom": {
       "version": "12.19.0",
       "license": "MIT",
@@ -14106,6 +14094,68 @@
       "resolved": "shared",
       "link": true
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-3.0.0.tgz",
+      "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.2.0.tgz",
+      "integrity": "sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.5.tgz",
+      "integrity": "sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "19.3.3",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
+      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^3.0.0",
+        "minimist": "^1.2.8",
+        "rw": "^1.3.3",
+        "sort-object": "^3.0.3"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -14883,6 +14933,46 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson-vt": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
+      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/mapbox-gl": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-3.4.1.tgz",
+      "integrity": "sha512-NsGKKtgW93B+UaLPti6B7NwlxYlES5DpV5Gzj9F75rK5ALKsqSk15CiEHbOnTr09RGbr6ZYiCdI+59NNNcAImg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/pbf": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
+      "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@vercel/analytics": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
@@ -14921,6 +15011,41 @@
           "optional": true
         },
         "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vis.gl/react-mapbox": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.1.tgz",
+      "integrity": "sha512-KMDTjtWESXxHS4uqWxjsvgQUHvuL3Z6SdKe68o7Nxma2qUfuyH3x4TCkIqGn3FQTrFvZLWvTnSAbGvtm+Kd13A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "mapbox-gl": ">=3.5.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vis.gl/react-maplibre": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.1.1.tgz",
+      "integrity": "sha512-iUOfzJAhFAJwEZp1644tQb7LOTFgi5/GzdaztkhzNgFVuoF2Ez7guvwZjQAKB9CN2TlHTgNuYH8UW85kO7cVhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@maplibre/maplibre-gl-style-spec": "^19.2.1"
+      },
+      "peerDependencies": {
+        "maplibre-gl": ">=4.0.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "maplibre-gl": {
           "optional": true
         }
       }
@@ -15124,6 +15249,15 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -15132,6 +15266,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/bidi-js": {
@@ -15144,6 +15287,25 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/bytewise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
+      }
+    },
+    "node_modules/bytewise-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -15153,6 +15315,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/cheap-ruler": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-4.1.0.tgz",
+      "integrity": "sha512-pmcgaGHAxfYtKr4BtSaM/+/3vvQJJLkvQibEdO2eb5eiHrRgEAd43M2tpBGi4eIX32kXyvPLQVT23qNnuFaa8w==",
+      "license": "ISC"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -15180,6 +15348,12 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -15240,6 +15414,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
@@ -15293,6 +15473,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -15339,6 +15531,27 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.3.tgz",
+      "integrity": "sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==",
+      "license": "ISC"
+    },
+    "node_modules/get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -15368,12 +15581,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -15434,9 +15677,21 @@
         }
       }
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
+      "license": "MIT"
+    },
     "node_modules/kartiiing": {
       "resolved": "kartiiing",
       "link": true
+    },
+    "node_modules/kdbush": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.1.0.tgz",
+      "integrity": "sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==",
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.30.2",
@@ -15729,6 +15984,55 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mapbox-gl": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.24.1.tgz",
+      "integrity": "sha512-e9Wj1TtGGOjzE/jtWaUvdFN7RYL3H0keEzH7gwzHbEdFAsmi03RaDVhnATmtFtIRXQUYf944CIQN0jQv+obeNg==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
+      "workspaces": [
+        "src/style-spec",
+        "plugins/mapbox-gl-pmtiles-provider",
+        "test/build/vite",
+        "test/build/webpack",
+        "test/build/typings"
+      ],
+      "dependencies": {
+        "@mapbox/mapbox-gl-supported": "^3.0.0",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/geojson-vt": "^3.2.5",
+        "@types/pbf": "^3.0.5",
+        "@types/supercluster": "^7.1.3",
+        "cheap-ruler": "^4.0.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^3.0.1",
+        "geojson-vt": "^4.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "martinez-polygon-clipping": "^0.8.1",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.0.0",
+        "quickselect": "^3.0.0",
+        "supercluster": "^8.0.1",
+        "tinyqueue": "^3.0.0"
+      }
+    },
+    "node_modules/martinez-polygon-clipping": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/martinez-polygon-clipping/-/martinez-polygon-clipping-0.8.1.tgz",
+      "integrity": "sha512-9PLLMzMPI6ihHox4Ns6LpVBLpRc7sbhULybZ/wyaY8sY3ECNe2+hxm1hA2/9bEEpRrdpjoeduBuZLg2aq1cSIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "robust-predicates": "^2.0.4",
+        "splaytree": "^0.1.4",
+        "tinyqueue": "3.0.0"
+      }
+    },
     "node_modules/masonic": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/masonic/-/masonic-4.1.0.tgz",
@@ -15767,6 +16071,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -15776,6 +16089,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -15826,6 +16145,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pbf": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.2.tgz",
+      "integrity": "sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -15875,6 +16206,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -15890,6 +16227,12 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -15898,6 +16241,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/raf-schd": {
       "version": "4.0.3",
@@ -15934,6 +16283,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-map-gl": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.1.tgz",
+      "integrity": "sha512-aSqFAFoxvY7wxbGI93Dz0E41171mkAb3GcNbnkFIotmu88OFw495os6mIDZSi7irYNT/PZEIOEHUxhun4ToGuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vis.gl/react-mapbox": "8.1.1",
+        "@vis.gl/react-maplibre": "8.1.1"
+      },
+      "peerDependencies": {
+        "mapbox-gl": ">=1.13.0",
+        "maplibre-gl": ">=1.13.0",
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      },
+      "peerDependenciesMeta": {
+        "mapbox-gl": {
+          "optional": true
+        },
+        "maplibre-gl": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -15956,6 +16329,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-2.0.4.tgz",
+      "integrity": "sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==",
+      "license": "Unlicense"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.12",
@@ -15998,6 +16386,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -16016,6 +16410,21 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -16039,11 +16448,89 @@
         "node": ">=18"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
+      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
+      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
+      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bytewise": "^1.1.0",
+        "get-value": "^2.0.2",
+        "is-extendable": "^0.1.1",
+        "sort-asc": "^0.2.0",
+        "sort-desc": "^0.2.0",
+        "union-value": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/splaytree": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-0.1.4.tgz",
+      "integrity": "sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==",
+      "license": "MIT"
+    },
+    "node_modules/split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split-string/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16073,6 +16560,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/symbol-tree": {
@@ -16144,6 +16640,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
@@ -16236,6 +16738,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typewise": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typewise-core": "^1.2.0"
+      }
+    },
+    "node_modules/typewise-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
@@ -16244,6 +16761,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/vite": {


### PR DESCRIPTION
- feat(calendar): implement infinite scroll and pagination
- Replace the static race events list with a paginated, infinite-scroll approach using a new `useInfiniteScroll` hook. Update the calendar client to fetch data in chunks via `IPaginatedResponse`, reuse shared `SearchHeader`, and simplify layout constants. This improves scalability and user experience when browsing many events.