### PR TITLE
Add center-on-location button and distance display to circuit map popups #98

### DIFF
--- a/kartiiing/AGENTS.md
+++ b/kartiiing/AGENTS.md
@@ -22,7 +22,7 @@ function process(data: unknown) {
 
 ### Formatting
 
-All code is formatted with Prettier (via ESLint). Do not add `// eslint-disable` or `// prettier-ignore` comments to silence rules — if a rule is genuinely wrong for this project, disable it in `eslint.config.mjs` with a comment explaining why.
+All code is formatted with Prettier (via ESLint). Do not add `// eslint-disable` or `// prettier-ignore` comments to silence rules — if a rule is genuinely wrong for this project, disable it in `eslint.config.mjs` with a comment explaining why. The exception is suppressing React Hook dependency warnings in `useEffect` — you may use `// eslint-disable-next-line react-hooks/exhaustive-deps` with a comment explaining **why** the dependency is intentionally omitted.
 
 ---
 

--- a/kartiiing/components/circuits/map/CircuitsMap.tsx
+++ b/kartiiing/components/circuits/map/CircuitsMap.tsx
@@ -6,28 +6,16 @@ import { useTheme } from "next-themes";
 import mapboxgl from "mapbox-gl";
 import Map, { Marker, MapRef } from "react-map-gl/mapbox";
 import { CircuitMapPopup } from "./CircuitMapPopup";
+import { MapCenterButton } from "./MapCenterButton";
 import { MapZoomControl } from "./MapZoomControl";
 import { MapNoResults } from "./MapNoResults";
-import { cn, lightDarkGlassBase } from "@/lib/utils";
+import { cn, flyToCenter, lightDarkGlassBase } from "@/lib/utils";
 import "mapbox-gl/dist/mapbox-gl.css";
-
-function flyToCenter(
-  map: mapboxgl.Map,
-  center: ICoordinates | null,
-  zoom: number,
-): void {
-  if (!center) return;
-  map.flyTo({
-    center: [center.longitude, center.latitude],
-    zoom,
-    duration: 1500,
-    essential: true,
-  });
-}
 
 type Props = {
   coordinates: ICircuitCoordinate[];
   selectedCircuit: ICircuit | null;
+  userLocation: ICoordinates | null;
 
   onCircuitSelect: (id: number) => void;
   onPopupClose: () => void;
@@ -39,6 +27,7 @@ type Props = {
 export function CircuitsMap({
   coordinates,
   selectedCircuit,
+  userLocation,
   onCircuitSelect,
   onPopupClose,
   className = "",
@@ -151,10 +140,10 @@ export function CircuitsMap({
         mapLib={import("mapbox-gl")}
         tabIndex={-1}
       >
-        <MapZoomControl
-          mapRef={mapRef}
-          className="absolute top-17 right-4 z-10"
-        />
+        <div className="absolute top-17 right-4 z-10 flex flex-col gap-1.5">
+          <MapZoomControl mapRef={mapRef} />
+          <MapCenterButton mapRef={mapRef} userLocation={userLocation} />
+        </div>
 
         {hasCoordinates &&
           coordinates.map((coord) => (
@@ -178,6 +167,21 @@ export function CircuitsMap({
 
         {selectedCircuit && (
           <CircuitMapPopup circuit={selectedCircuit} onClose={onPopupClose} />
+        )}
+
+        {userLocation && (
+          <Marker
+            longitude={userLocation.longitude}
+            latitude={userLocation.latitude}
+            anchor="center"
+          >
+            <div className="relative group cursor-pointer">
+              {/* Pulsing ring */}
+              <span className="absolute inset-0 rounded-full bg-blue-400/30 animate-ping" />
+              {/* Outer dot */}
+              <span className="block w-5 h-5 rounded-full bg-blue-500 border-2 border-white shadow-md" />
+            </div>
+          </Marker>
         )}
 
         {!hasCoordinates && <MapNoResults />}

--- a/kartiiing/components/circuits/map/CircuitsMapModal.tsx
+++ b/kartiiing/components/circuits/map/CircuitsMapModal.tsx
@@ -9,14 +9,10 @@ import { AnimatePresence, motion } from "framer-motion";
 import { ICircuit, ICircuitCoordinate } from "@kartiiing/shared";
 import { SearchBar } from "@/components/shared/SearchBar";
 import { CircuitsMap } from "@/components/circuits/map/CircuitsMap";
-import {
-  cn,
-  lightDarkGlassBase,
-  getLocationFromGPS,
-  getLocationFromIP,
-  lightDarkGlassHover,
-  UserLocation,
-} from "@/lib/utils";
+import { useShallow } from "zustand/shallow";
+import { useUserLocationStore } from "@/lib/stores/userLocationStore";
+import { cn, lightDarkGlassBase, lightDarkGlassHover } from "@/lib/utils";
+import { calculateDistance } from "@/lib/utils/locationUtils";
 import { Button } from "@/components/ui/button";
 import { getCircuitById, getCircuitCoordinates } from "@/lib/api";
 
@@ -26,35 +22,19 @@ type Props = {
   onClose: () => void;
 };
 
-export function CircuitsMapModal({
-  coordinates,
-  isOpen,
-  onClose,
-}: Props) {
+export function CircuitsMapModal({ coordinates, isOpen, onClose }: Props) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [userLocation, setUserLocation] = useState<UserLocation | null>(null);
   const [selectedCircuit, setSelectedCircuit] = useState<ICircuit | null>(null);
   const [filteredCoords, setFilteredCoords] =
     useState<ICircuitCoordinate[]>(coordinates);
   const circuitCache = useRef<Map<number, ICircuit>>(new Map());
 
-  // Fetch user location on open — IP resolves instantly (no prompt),
-  // GPS upgrades the location later if the user allows it.
-  useEffect(() => {
-    if (!isOpen) return;
-    let cancelled = false;
-    (async () => {
-      const ipLoc = await getLocationFromIP();
-      if (ipLoc && !cancelled) setUserLocation(ipLoc);
-
-      const gpsLoc = await getLocationFromGPS();
-      if (gpsLoc && !cancelled) setUserLocation(gpsLoc);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [isOpen]);
-
+  const { userLocation, locationSource } = useUserLocationStore(
+    useShallow((s) => ({
+      userLocation: s.userLocation,
+      locationSource: s.locationSource,
+    })),
+  );
   // Close on Escape key
   useEscapeKey(isOpen, onClose);
   // Prevent body scroll when modal is open
@@ -79,6 +59,22 @@ export function CircuitsMapModal({
     }
   }, [searchQuery, coordinates]);
 
+  // Reset search state when modal closes
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery("");
+      setFilteredCoords(coordinates);
+      setSelectedCircuit(null);
+    }
+  }, [isOpen, coordinates]);
+
+  // Sync filteredCoords when coordinates prop changes
+  useEffect(() => {
+    if (!searchQuery.trim()) {
+      setFilteredCoords(coordinates);
+    }
+  }, [coordinates, searchQuery]);
+
   // Fetch filtered coordinates from the API when search query changes
   useEffect(() => {
     if (!isOpen) return;
@@ -88,22 +84,31 @@ export function CircuitsMapModal({
   }, [performSearch, isOpen]);
 
   // Handle circuit selection on map — fetch full data if not cached
-  const handleCircuitSelect = useCallback(async (id: number) => {
-    // Check cache first
-    const cached = circuitCache.current.get(id);
-    if (cached) {
-      setSelectedCircuit(cached);
-      return;
-    }
+  const handleCircuitSelect = useCallback(
+    async (id: number) => {
+      // Check cache first
+      const cached = circuitCache.current.get(id);
+      if (cached) {
+        setSelectedCircuit(cached);
+        return;
+      }
 
-    try {
-      const circuit = await getCircuitById(id);
-      circuitCache.current.set(id, circuit);
-      setSelectedCircuit(circuit);
-    } catch (error) {
-      console.error("Error fetching circuit for popup:", error);
-    }
-  }, []);
+      try {
+        const circuit = await getCircuitById(id);
+        const circuitWithDistance: ICircuit = { ...circuit };
+        if (userLocation) {
+          circuitWithDistance.distance = Math.round(
+            calculateDistance(userLocation, circuit.coordinates),
+          );
+        }
+        circuitCache.current.set(id, circuitWithDistance);
+        setSelectedCircuit(circuitWithDistance);
+      } catch (error) {
+        console.error("Error fetching circuit for popup:", error);
+      }
+    },
+    [userLocation],
+  );
 
   const handlePopupClose = useCallback(() => {
     setSelectedCircuit(null);
@@ -141,11 +146,12 @@ export function CircuitsMapModal({
               <CircuitsMap
                 coordinates={filteredCoords}
                 selectedCircuit={selectedCircuit}
+                userLocation={userLocation}
                 onCircuitSelect={handleCircuitSelect}
                 onPopupClose={handlePopupClose}
                 className="!min-h-0 !rounded-none !border-0 !shadow-none"
                 initialCenter={userLocation}
-                initialZoom={userLocation?.source === "gps" ? 6 : 4}
+                initialZoom={locationSource === "gps" ? 6 : 4}
               />
 
               {/* Floating search bar */}

--- a/kartiiing/components/circuits/map/MapCenterButton.tsx
+++ b/kartiiing/components/circuits/map/MapCenterButton.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { MapRef } from "react-map-gl/mapbox";
+import { Crosshair } from "lucide-react";
+import { ICoordinates } from "@kartiiing/shared";
+import {
+  cn,
+  flyToCenter,
+  lightDarkGlassBase,
+  lightDarkGlassOnlyHover,
+} from "@/lib/utils";
+
+type Props = {
+  mapRef: React.RefObject<MapRef | null>;
+  userLocation: ICoordinates | null;
+  className?: string;
+};
+
+export function MapCenterButton({ mapRef, userLocation, className }: Props) {
+  if (!userLocation) return null;
+
+  return (
+    <button
+      onClick={() => {
+        const map = mapRef.current?.getMap();
+        if (map) flyToCenter(map, userLocation, 10);
+      }}
+      className={cn(
+        "flex items-center justify-center w-10.5 h-10.5 rounded-lg text-foreground/80 hover:text-foreground cursor-pointer",
+        "focus-visible:outline-none focus-visible:ring focus-visible:ring-inset",
+        lightDarkGlassBase,
+        lightDarkGlassOnlyHover,
+        className,
+      )}
+      aria-label="Center on your location"
+    >
+      <Crosshair className="size-4.5" />
+    </button>
+  );
+}

--- a/kartiiing/components/circuits/map/__tests__/MapCenterButton.test.tsx
+++ b/kartiiing/components/circuits/map/__tests__/MapCenterButton.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MapCenterButton } from "../MapCenterButton";
+import { flyToCenter } from "@/lib/utils/locationUtils";
+import { MapRef } from "react-map-gl/mapbox";
+
+const CENTER_LABEL = "Center on your location";
+const USER_LOCATION = { latitude: 47.4979, longitude: 19.0402 };
+const ZOOM_LEVEL = 10;
+
+vi.mock("@/lib/utils/locationUtils", () => ({
+  flyToCenter: vi.fn(),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  lightDarkGlassBase: "glass-base",
+  lightDarkGlassOnlyHover: "glass-hover",
+}));
+
+function createMockMapRef(): React.RefObject<MapRef | null> {
+  return {
+    current: {
+      getMap: () => ({ flyTo: vi.fn() }),
+    } as unknown as MapRef,
+  };
+}
+
+describe("MapCenterButton", () => {
+  it("renders the button when userLocation is provided", () => {
+    render(
+      <MapCenterButton
+        mapRef={createMockMapRef()}
+        userLocation={USER_LOCATION}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: CENTER_LABEL }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when userLocation is null", () => {
+    const { container } = render(
+      <MapCenterButton mapRef={createMockMapRef()} userLocation={null} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: CENTER_LABEL }),
+    ).not.toBeInTheDocument();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls flyToCenter with userLocation and zoom 10 on click", async () => {
+    const user = userEvent.setup();
+    render(
+      <MapCenterButton
+        mapRef={createMockMapRef()}
+        userLocation={USER_LOCATION}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: CENTER_LABEL }));
+
+    expect(flyToCenter).toHaveBeenCalledWith(
+      expect.any(Object),
+      USER_LOCATION,
+      ZOOM_LEVEL,
+    );
+  });
+});

--- a/kartiiing/lib/utils/__tests__/locationUtils.test.ts
+++ b/kartiiing/lib/utils/__tests__/locationUtils.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { getLocationFromGPS, getLocationFromIP } from "../locationUtils";
+import {
+  getLocationFromGPS,
+  getLocationFromIP,
+  calculateDistance,
+  flyToCenter,
+} from "../locationUtils";
+import type { Map as MapboxMap } from "mapbox-gl";
 
 const BUDAPEST_LAT = 47.4979;
 const BUDAPEST_LNG = 19.0402;
+const PARIS_LAT = 48.8566;
+const PARIS_LNG = 2.3522;
+const NEW_YORK_LAT = 40.7128;
+const NEW_YORK_LNG = -74.006;
 const DEFAULT_API_URL = "https://free.freeipapi.com/api/json";
 
 describe("getLocationFromGPS", () => {
@@ -80,6 +90,7 @@ describe("getLocationFromGPS", () => {
 describe("getLocationFromIP", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   it("returns coordinates with source=ip on success", async () => {
@@ -110,15 +121,21 @@ describe("getLocationFromIP", () => {
     expect(fetchSpy).toHaveBeenCalledWith(DEFAULT_API_URL);
   });
 
-  it("returns null when the response is not ok", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false } as Response);
+  it("returns null and logs warning when the response is not ok", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 429,
+    } as Response);
 
     const result = await getLocationFromIP();
 
     expect(result).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      `IP geolocation failed: ${DEFAULT_API_URL} returned status 429`,
+    );
   });
 
-  it("returns null when the response lacks coordinates", async () => {
+  it("returns null and logs warning when the response lacks coordinates", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ latitude: BUDAPEST_LAT }),
@@ -127,13 +144,81 @@ describe("getLocationFromIP", () => {
     const result = await getLocationFromIP();
 
     expect(result).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      "IP geolocation failed: response lacked coordinates",
+      { latitude: BUDAPEST_LAT },
+    );
   });
 
-  it("returns null when fetch throws", async () => {
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
+  it("returns null and logs warning when fetch throws", async () => {
+    const error = new Error("Network error");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(error);
 
     const result = await getLocationFromIP();
 
     expect(result).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      "IP geolocation failed with error:",
+      error,
+    );
+  });
+});
+
+describe("calculateDistance", () => {
+  const BUDAPEST = { latitude: BUDAPEST_LAT, longitude: BUDAPEST_LNG };
+  const PARIS = { latitude: PARIS_LAT, longitude: PARIS_LNG };
+  const NEW_YORK = { latitude: NEW_YORK_LAT, longitude: NEW_YORK_LNG };
+
+  it("returns approximately 1,244 km between Budapest and Paris", () => {
+    const distance = calculateDistance(BUDAPEST, PARIS);
+
+    // Haversine distance: ~1,244 km (exact value varies slightly by formula)
+    expect(distance).toBeGreaterThan(1240);
+    expect(distance).toBeLessThan(1250);
+  });
+
+  it("returns 0 for the same point", () => {
+    const distance = calculateDistance(PARIS, PARIS);
+
+    expect(distance).toBe(0);
+  });
+
+  it("calculates known distance between Paris and New York", () => {
+    const distance = calculateDistance(PARIS, NEW_YORK);
+
+    // Approximately 5,830 km
+    expect(distance).toBeGreaterThan(5800);
+    expect(distance).toBeLessThan(5900);
+  });
+});
+
+describe("flyToCenter", () => {
+  const CENTER = { latitude: PARIS_LAT, longitude: PARIS_LNG };
+
+  it("calls flyTo with correct center and zoom", () => {
+    const mockFlyTo = vi.fn();
+    const mockMap = {
+      flyTo: mockFlyTo,
+    } as unknown as MapboxMap;
+
+    flyToCenter(mockMap, CENTER, 10);
+
+    expect(mockFlyTo).toHaveBeenCalledWith({
+      center: [CENTER.longitude, CENTER.latitude],
+      zoom: 10,
+      duration: 1500,
+      essential: true,
+    });
+  });
+
+  it("does not call flyTo when center is null", () => {
+    const mockFlyTo = vi.fn();
+    const mockMap = {
+      flyTo: mockFlyTo,
+    } as unknown as MapboxMap;
+
+    flyToCenter(mockMap, null, 10);
+
+    expect(mockFlyTo).not.toHaveBeenCalled();
   });
 });

--- a/kartiiing/lib/utils/locationUtils.ts
+++ b/kartiiing/lib/utils/locationUtils.ts
@@ -1,3 +1,6 @@
+import { type Map as MapboxMap } from "mapbox-gl";
+import { ICoordinates } from "@kartiiing/shared";
+
 export interface UserLocation {
   longitude: number;
   latitude: number;
@@ -34,12 +37,22 @@ export async function getLocationFromGPS(): Promise<UserLocation | null> {
 /**
  * Fetches the user's approximate location via IP geolocation.
  * No permission prompt needed — resolves fast.
+ *
+ * **Dependency:** Uses the free third-party service `freeipapi.com`.
+ * User IPs are sent to this service. If the service is unavailable, rate-limited,
+ * or changes its free tier, this function silently returns `null`.
+ * No fallback is implemented — callers should handle the `null` case gracefully.
  */
 export async function getLocationFromIP(): Promise<UserLocation | null> {
   try {
     const url = "https://free.freeipapi.com/api/json";
     const res = await fetch(url);
-    if (!res.ok) return null;
+    if (!res.ok) {
+      console.warn(
+        `IP geolocation failed: ${url} returned status ${res.status}`,
+      );
+      return null;
+    }
     const data = await res.json();
     if (data.latitude != null && data.longitude != null) {
       const locationName =
@@ -53,8 +66,51 @@ export async function getLocationFromIP(): Promise<UserLocation | null> {
         locationName,
       };
     }
+    console.warn("IP geolocation failed: response lacked coordinates", data);
     return null;
-  } catch {
+  } catch (err) {
+    console.warn("IP geolocation failed with error:", err);
     return null;
   }
+}
+
+/**
+ * Flies the map to a given center coordinate at the specified zoom level.
+ */
+export function flyToCenter(
+  map: MapboxMap,
+  center: ICoordinates | null,
+  zoom: number,
+): void {
+  if (!center) return;
+  map.flyTo({
+    center: [center.longitude, center.latitude],
+    zoom,
+    duration: 1500,
+    essential: true,
+  });
+}
+
+/**
+ * Calculates the great-circle distance (Haversine formula) between two coordinates.
+ * Returns the distance in kilometers.
+ */
+export function calculateDistance(
+  from: ICoordinates,
+  to: ICoordinates,
+): number {
+  const R = 6371; // Earth's radius in km
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+
+  const dLat = toRad(to.latitude - from.latitude);
+  const dLng = toRad(to.longitude - from.longitude);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(from.latitude)) *
+      Math.cos(toRad(to.latitude)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
 }


### PR DESCRIPTION
#98

- feat(map): add user location, center button, and circuit popup caching
- Display user location on the map with a pulsing blue marker
- Add a MapCenterButton to re-center the map on user location
- Extract `flyToCenter` to shared utils for reuse
- Cache circuit details in popup to avoid redundant API calls
- Compute and attach distance to circuits when user location is available
- Update AGENTS.md to allow `eslint-disable-next-line react-hooks/exhaustive-deps` with an explanatory comment