### PR TITLE
Circuit length multiple layouts #105

### DIFF
--- a/kartiiing/components/circuit/CircuitCard.tsx
+++ b/kartiiing/components/circuit/CircuitCard.tsx
@@ -2,7 +2,7 @@ import { ICircuit } from "@kartiiing/shared";
 import { CircuitActionLinks } from "@/components/circuit/CircuitActionLinks";
 import { CircuitInfoContent } from "@/components/circuit/CircuitInfoContent";
 import { RaceLocation } from "@/components/shared/race-data/RaceLocation";
-import { CircuitMetric } from "@/components/shared/badges/CircuitMetricBadge";
+import { CircuitMetric } from "@/components/circuit/CircuitMetric";
 import { cn, lightDarkGlassHover } from "@/lib/utils";
 
 type Props = {
@@ -40,7 +40,11 @@ export function CircuitCard({
           {showDistance ? (
             <CircuitMetric value={circuit.distance!} type="distance" />
           ) : (
-            <CircuitMetric value={circuit.length} type="length" />
+            <CircuitMetric
+              value={circuit.length}
+              type="length"
+              layouts={circuit.layouts}
+            />
           )}
           <CircuitActionLinks
             circuit={circuit}

--- a/kartiiing/components/circuit/CircuitInfo.tsx
+++ b/kartiiing/components/circuit/CircuitInfo.tsx
@@ -39,7 +39,7 @@ export function CircuitInfo({ circuit, race }: Props) {
       </div>
 
       <div className="p-3.5">
-        <CircuitInfoContent circuit={circuit} />
+        <CircuitInfoContent circuit={circuit} showLayoutRange={false} />
         {circuit.circuitFastestLaps &&
           circuit.circuitFastestLaps.length > 0 && (
             <div className="mt-3 pt-4 border-t border-gray-300 dark:border-gray-700">

--- a/kartiiing/components/circuit/CircuitInfoContent.tsx
+++ b/kartiiing/components/circuit/CircuitInfoContent.tsx
@@ -1,18 +1,20 @@
 import { ICircuit } from "@kartiiing/shared";
 import { CircuitActionLinks } from "@/components/circuit/CircuitActionLinks";
 import { RaceLocation } from "@/components/shared/race-data/RaceLocation";
-import { CircuitMetric } from "@/components/shared/badges/CircuitMetricBadge";
+import { CircuitMetric } from "./CircuitMetric";
 
 type Props = {
   circuit: ICircuit;
   showActions?: boolean;
   headingLevel?: "h2" | "h3";
+  showLayoutRange?: boolean;
 };
 
 export function CircuitInfoContent({
   circuit,
   showActions = true,
   headingLevel = "h3",
+  showLayoutRange = true,
 }: Props) {
   const showDistance = circuit.distance != null;
   const HeadingTag = headingLevel === "h2" ? "h2" : "h3";
@@ -30,7 +32,11 @@ export function CircuitInfoContent({
         {showDistance ? (
           <CircuitMetric value={circuit.distance!} type="distance" />
         ) : (
-          <CircuitMetric value={circuit.length} type="length" />
+          <CircuitMetric
+            value={circuit.length}
+            type="length"
+            layouts={showLayoutRange ? circuit.layouts : undefined}
+          />
         )}
       </div>
       {showActions && (

--- a/kartiiing/components/circuit/CircuitMetric.tsx
+++ b/kartiiing/components/circuit/CircuitMetric.tsx
@@ -1,6 +1,7 @@
 import { Ruler, Route } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUserLocationStore } from "@/lib/stores/userLocationStore";
+import type { ICircuitLayout } from "@kartiiing/shared";
 
 type MetricType = "length" | "distance";
 
@@ -8,6 +9,7 @@ type Props = {
   value: number;
   type: MetricType;
   className?: string;
+  layouts?: ICircuitLayout[];
 };
 
 const ICON_MAP: Record<MetricType, typeof Ruler> = {
@@ -24,14 +26,29 @@ function getTooltip(type: MetricType, locationName?: string): string {
   return "Circuit length";
 }
 
-function formatValue(value: number, type: MetricType): string {
+function formatValue(
+  value: number,
+  type: MetricType,
+  layouts?: ICircuitLayout[],
+): string {
   if (type === "distance") {
     return Math.round(value) + " km";
   }
+
+  if (layouts && layouts.length > 1) {
+    const lengths = layouts.map((l) => l.length);
+    const min = Math.min(...lengths);
+    const max = Math.max(...lengths);
+
+    if (min !== max) {
+      return `${min} - ${max} m`;
+    }
+  }
+
   return `${value} m`;
 }
 
-export function CircuitMetric({ value, type, className }: Props) {
+export function CircuitMetric({ value, type, className, layouts }: Props) {
   const locationName = useUserLocationStore((state) => state.locationName);
 
   if (value == null || value <= 0) return null;
@@ -47,7 +64,7 @@ export function CircuitMetric({ value, type, className }: Props) {
       )}
     >
       <Icon size={14} />
-      {formatValue(value, type)}
+      {formatValue(value, type, layouts)}
     </span>
   );
 

--- a/kartiiing/components/circuit/__tests__/CircuitInfoContent.test.tsx
+++ b/kartiiing/components/circuit/__tests__/CircuitInfoContent.test.tsx
@@ -12,6 +12,15 @@ import { useUserLocationStore } from "@/lib/stores/userLocationStore";
 const VISIT_LINK_LABEL = "Visit circuit website";
 const MAPS_LINK_LABEL = "Open in Google Maps";
 
+const MULTI_LAYOUT_CIRCUIT = buildCircuitDetail({
+  name: "Test Circuit",
+  length: 1200,
+  layouts: [
+    { id: 1, name: "Short", length: 855 },
+    { id: 2, name: "Full", length: 1200 },
+  ],
+});
+
 describe("CircuitInfoContent", () => {
   beforeEach(() => {
     vi.mocked(useUserLocationStore).mockImplementation((selector: unknown) => {
@@ -95,5 +104,23 @@ describe("CircuitInfoContent", () => {
 
     expect(screen.queryByText(/\d+ m/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\d+ km/)).not.toBeInTheDocument();
+  });
+
+  it("renders a range when circuit has multiple layouts by default", () => {
+    render(<CircuitInfoContent circuit={MULTI_LAYOUT_CIRCUIT} />);
+
+    expect(screen.getByText("855 - 1200 m")).toBeInTheDocument();
+  });
+
+  it("renders a single value when showLayoutRange is false", () => {
+    render(
+      <CircuitInfoContent
+        circuit={MULTI_LAYOUT_CIRCUIT}
+        showLayoutRange={false}
+      />,
+    );
+
+    expect(screen.getByText("1200 m")).toBeInTheDocument();
+    expect(screen.queryByText("855 - 1200 m")).not.toBeInTheDocument();
   });
 });

--- a/kartiiing/components/circuit/__tests__/CircuitMetric.test.tsx
+++ b/kartiiing/components/circuit/__tests__/CircuitMetric.test.tsx
@@ -1,12 +1,24 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { CircuitMetric } from "../CircuitMetricBadge";
+import { CircuitMetric } from "../CircuitMetric";
 
 vi.mock("@/lib/stores/userLocationStore", () => ({
   useUserLocationStore: vi.fn(),
 }));
 
 import { useUserLocationStore } from "@/lib/stores/userLocationStore";
+
+const TWO_LAYOUTS = [
+  { id: 1, name: "Short", length: 855 },
+  { id: 2, name: "Full", length: 1200 },
+];
+
+const SAME_LENGTH_LAYOUTS = [
+  { id: 1, name: "Layout A", length: 1000 },
+  { id: 2, name: "Layout B", length: 1000 },
+];
+
+const ONE_LAYOUT = [{ id: 1, name: "Full Circuit", length: 1122 }];
 
 describe("CircuitMetric", () => {
   beforeEach(() => {
@@ -77,5 +89,42 @@ describe("CircuitMetric", () => {
     for (const el of elements) {
       expect(el.closest("span[title]")).toBeNull();
     }
+  });
+
+  it("renders a range when layouts have multiple distinct lengths", () => {
+    render(<CircuitMetric value={1200} type="length" layouts={TWO_LAYOUTS} />);
+
+    expect(screen.getByText("855 - 1200 m")).toBeInTheDocument();
+  });
+
+  it("renders a single value when layouts have the same length", () => {
+    render(
+      <CircuitMetric
+        value={1000}
+        type="length"
+        layouts={SAME_LENGTH_LAYOUTS}
+      />,
+    );
+
+    expect(screen.getByText("1000 m")).toBeInTheDocument();
+  });
+
+  it("renders a single value when there is only one layout", () => {
+    render(<CircuitMetric value={1122} type="length" layouts={ONE_LAYOUT} />);
+
+    expect(screen.getByText("1122 m")).toBeInTheDocument();
+  });
+
+  it("renders a single value when layouts is an empty array", () => {
+    render(<CircuitMetric value={1070} type="length" layouts={[]} />);
+
+    expect(screen.getByText("1070 m")).toBeInTheDocument();
+  });
+
+  it("renders distance normally even when layouts are provided", () => {
+    render(<CircuitMetric value={5} type="distance" layouts={TWO_LAYOUTS} />);
+
+    expect(screen.getByText("5 km")).toBeInTheDocument();
+    expect(screen.queryByText(/855 - 1200 m/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Relocate CircuitMetric from shared/badges to circuit components and extend it with a `layouts` prop. When the circuit has more than one layout and their lengths differ, formatValue now renders a min–max range (e.g., "1200 - 1500 m") instead of a single value. Update CircuitCard to pass layouts automatically. Add a `showLayoutRange` prop to CircuitInfoContent (default true) and set it to false inside CircuitInfo to keep the dedicated info view unchanged.