### PR TITLE
Client-side error on slow connections #107

### DIFF
--- a/api/src/race-events/race-events.service.ts
+++ b/api/src/race-events/race-events.service.ts
@@ -8,6 +8,7 @@ import {
   IWeatherDataDay,
   IRaceEventDateMinimal,
   RaceStatus,
+  emptyPaginatedResponse,
 } from '@kartiiing/shared';
 import {
   toIRaceEvent,
@@ -134,9 +135,7 @@ export class RaceEventsService {
     const paginatedEvents = filteredEvents.slice(skip, skip + pageSize);
 
     if (paginatedEvents.length === 0) {
-      throw new NotFoundException(
-        year ? `No race events found for year ${year}` : `No race events found`,
-      );
+      return emptyPaginatedResponse<IRaceEvent>(pageNumber, pageSize);
     }
 
     const data = this.transformEvents(paginatedEvents, includeStatus);

--- a/kartiiing/app/calendar/[year]/calendar-client.tsx
+++ b/kartiiing/app/calendar/[year]/calendar-client.tsx
@@ -7,6 +7,7 @@ import { SearchHeader } from "@/components/shared/SearchHeader";
 import { CalendarActions } from "@/components/calendar/CalendarActions";
 import { RacesGrid } from "@/components/calendar/RacesGrid";
 import { BackToTopBtn } from "@/components/shared/btns/BackToTopBtn";
+import { ErrorState } from "@/components/shared/ErrorState";
 import {
   IRaceEvent,
   CalendarOrderPreset,
@@ -19,14 +20,21 @@ type Props = {
   initialData: IPaginatedResponse<IRaceEvent>;
   year: string;
   initialSort: CalendarOrderPreset;
+  serverError?: string;
 };
 
 const PAGE_SIZE = 20;
 
-export function CalendarClient({ initialData, year, initialSort }: Props) {
+export function CalendarClient({
+  initialData,
+  year,
+  initialSort,
+  serverError,
+}: Props) {
   const [loading, setLoading] = useState(false);
   const [preset, setPreset] = useState<CalendarOrderPreset>(initialSort);
   const [searchQuery, setSearchQuery] = useState("");
+  const [clientError, setClientError] = useState<string | null>(null);
   const { sectionRef, sectionWidth } = useSectionWidth();
 
   const fetchRaces = useCallback(
@@ -57,6 +65,8 @@ export function CalendarClient({ initialData, year, initialSort }: Props) {
   });
 
   useEffect(() => {
+    setClientError(null);
+
     if (!searchQuery.trim() && preset === initialSort) {
       reset();
       return;
@@ -73,7 +83,9 @@ export function CalendarClient({ initialData, year, initialSort }: Props) {
         );
       } catch (error) {
         console.error("Error fetching races:", error);
-        replaceData([], 0, false);
+        setClientError(
+          "Failed to load races. Check your internet connection and try again.",
+        );
       } finally {
         setLoading(false);
       }
@@ -121,13 +133,20 @@ export function CalendarClient({ initialData, year, initialSort }: Props) {
         </div>
 
         <div className="my-4 py-4 border-t border-dashed">
-          <RacesGrid
-            races={displayedRaces}
-            loading={loading}
-            sectionWidth={sectionWidth}
-            loadingMore={loadingMore}
-            isAllYearsView={year === "all"}
-          />
+          {serverError || clientError ? (
+            <ErrorState
+              title="Something went wrong"
+              message={serverError || clientError || ""}
+            />
+          ) : (
+            <RacesGrid
+              races={displayedRaces}
+              loading={loading}
+              sectionWidth={sectionWidth}
+              loadingMore={loadingMore}
+              isAllYearsView={year === "all"}
+            />
+          )}
 
           {showSentinel && <div ref={sentinelRef} className="h-2 w-full" />}
         </div>

--- a/kartiiing/app/calendar/[year]/error.tsx
+++ b/kartiiing/app/calendar/[year]/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorState } from "@/components/shared/ErrorState";
+
+type Props = {
+  error: Error & { digest?: string };
+};
+
+export default function CalendarError({ error }: Props) {
+  useEffect(() => {
+    console.error("Calendar page error:", error);
+  }, [error]);
+
+  return (
+    <ErrorState
+      title="Something went wrong"
+      message="We couldn't load the calendar. Check your internet connection and try again."
+    />
+  );
+}

--- a/kartiiing/app/calendar/[year]/page.tsx
+++ b/kartiiing/app/calendar/[year]/page.tsx
@@ -6,7 +6,8 @@ import {
 import { CalendarClient } from "./calendar-client";
 import { CalendarHeader } from "@/components/calendar/CalendarHeader";
 import { PageWrapper } from "@/components/shared/PageWrapper";
-import { CalendarOrderPreset } from "@kartiiing/shared";
+import { CalendarOrderPreset, emptyPaginatedResponse } from "@kartiiing/shared";
+import type { IRaceEvent } from "@kartiiing/shared";
 import { SITE_URL } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
@@ -59,13 +60,31 @@ export default async function CalendarPage({ params }: Props) {
   const { year } = await params;
 
   const initialPreset = CalendarOrderPreset.ALL_ASC;
-  const racesRes = await getRaceEvents({
-    year: year,
-    preset: initialPreset,
-    page: 1,
-    limit: 20,
-  });
-  const availableYears = await getAvailableYears();
+
+  let racesRes: Awaited<ReturnType<typeof getRaceEvents>>;
+  let serverError: string | undefined;
+  try {
+    racesRes = await getRaceEvents({
+      year: year,
+      preset: initialPreset,
+      page: 1,
+      limit: 20,
+    });
+  } catch (error) {
+    console.error("Error fetching race events:", error);
+    racesRes = emptyPaginatedResponse<IRaceEvent>(1, 20);
+    serverError =
+      "Failed to load races. Check your internet connection and try again.";
+  }
+
+  const currentYear = new Date().getFullYear();
+  let availableYears: number[];
+  try {
+    availableYears = await getAvailableYears();
+  } catch (error) {
+    console.error("Error fetching available years:", error);
+    availableYears = [currentYear];
+  }
   const years = ["all", ...availableYears] as (string | number)[];
 
   let description = "Race calendar - view upcoming and past events.";
@@ -87,6 +106,7 @@ export default async function CalendarPage({ params }: Props) {
         initialData={racesRes}
         year={year}
         initialSort={initialPreset}
+        serverError={serverError}
       />
     </PageWrapper>
   );

--- a/kartiiing/app/calendar/page.tsx
+++ b/kartiiing/app/calendar/page.tsx
@@ -4,16 +4,22 @@ import { getAvailableYears } from "@/lib/api";
 export const dynamic = "force-dynamic";
 
 export default async function CalendarPage() {
-  const availableYears = await getAvailableYears();
   const currentYear = new Date().getFullYear();
   let targetYear = currentYear;
 
-  if (availableYears.length > 0) {
-    if (availableYears.includes(currentYear)) {
-      targetYear = currentYear;
-    } else {
-      targetYear = Math.max(...availableYears);
+  try {
+    const availableYears = await getAvailableYears();
+    if (availableYears.length > 0) {
+      if (availableYears.includes(currentYear)) {
+        targetYear = currentYear;
+      } else {
+        targetYear = Math.max(...availableYears);
+      }
     }
+  } catch (error) {
+    console.error("Error fetching available years:", error);
+    // Fall through with currentYear
   }
+
   redirect(`/calendar/${targetYear}`);
 }

--- a/kartiiing/app/circuits/circuits-client.tsx
+++ b/kartiiing/app/circuits/circuits-client.tsx
@@ -10,6 +10,7 @@ import { SearchHeader } from "@/components/shared/SearchHeader";
 import { CircuitsActions } from "@/components/circuits/CircuitsActions";
 import { CircuitsGrid } from "@/components/circuits/CircuitsGrid";
 import { BackToTopBtn } from "@/components/shared/btns/BackToTopBtn";
+import { ErrorState } from "@/components/shared/ErrorState";
 import { getCircuits } from "@/lib/api";
 import {
   ICircuit,
@@ -21,6 +22,7 @@ import {
 type Props = {
   initialData: IPaginatedResponse<ICircuit>;
   coordinates: ICircuitCoordinate[];
+  serverError?: string;
 };
 
 const PAGE_SIZE = 20;
@@ -30,9 +32,14 @@ const DISTANCE_PRESETS = [
   CircuitsOrderPreset.DISTANCE_DESC,
 ];
 
-export function CircuitsClient({ initialData, coordinates }: Props) {
+export function CircuitsClient({
+  initialData,
+  coordinates,
+  serverError,
+}: Props) {
   const [searchQuery, setSearchQuery] = useState("");
   const [loading, setLoading] = useState(false);
+  const [clientError, setClientError] = useState<string | null>(null);
   const [preset, setPreset] = useState<CircuitsOrderPreset>(
     CircuitsOrderPreset.LOCATION_ASC,
   );
@@ -83,6 +90,8 @@ export function CircuitsClient({ initialData, coordinates }: Props) {
 
   // Server-side search and preset changes: replace accumulated data
   useEffect(() => {
+    setClientError(null);
+
     if (!searchQuery.trim() && preset === CircuitsOrderPreset.LOCATION_ASC) {
       reset();
       return;
@@ -99,7 +108,9 @@ export function CircuitsClient({ initialData, coordinates }: Props) {
         );
       } catch (error) {
         console.error("Error fetching circuits:", error);
-        replaceData([], 0, false);
+        setClientError(
+          "Failed to load circuits. Check your internet connection and try again.",
+        );
       } finally {
         setLoading(false);
       }
@@ -155,12 +166,19 @@ export function CircuitsClient({ initialData, coordinates }: Props) {
         </div>
 
         <div className="my-4 py-4 border-t border-dashed">
-          <CircuitsGrid
-            circuits={displayedCircuits}
-            loading={loading}
-            sectionWidth={sectionWidth}
-            loadingMore={loadingMore}
-          />
+          {serverError || clientError ? (
+            <ErrorState
+              title="Something went wrong"
+              message={serverError || clientError || ""}
+            />
+          ) : (
+            <CircuitsGrid
+              circuits={displayedCircuits}
+              loading={loading}
+              sectionWidth={sectionWidth}
+              loadingMore={loadingMore}
+            />
+          )}
 
           {showSentinel && <div ref={sentinelRef} className="h-2 w-full" />}
         </div>

--- a/kartiiing/app/circuits/error.tsx
+++ b/kartiiing/app/circuits/error.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { ErrorState } from "@/components/shared/ErrorState";
+
+type Props = {
+  error: Error & { digest?: string };
+};
+
+export default function CircuitsError({ error }: Props) {
+  useEffect(() => {
+    console.error("Circuits page error:", error);
+  }, [error]);
+
+  return (
+    <ErrorState
+      title="Something went wrong"
+      message="We couldn't load the circuits. Check your internet connection and try again."
+    />
+  );
+}

--- a/kartiiing/app/circuits/page.tsx
+++ b/kartiiing/app/circuits/page.tsx
@@ -6,6 +6,8 @@ import {
   getCircuitsMetadata,
   getCircuitCoordinates,
 } from "@/lib/api";
+import { emptyPaginatedResponse } from "@kartiiing/shared";
+import type { ICircuit, ICircuitCoordinate } from "@kartiiing/shared";
 import { SITE_URL } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
@@ -42,8 +44,25 @@ export async function generateMetadata() {
 }
 
 export default async function CircuitsPage() {
-  const initialData = await getCircuits({ page: 1, limit: 20 });
-  const coordinates = await getCircuitCoordinates();
+  let initialData: Awaited<ReturnType<typeof getCircuits>>;
+  let coordinates: ICircuitCoordinate[];
+  let serverError: string | undefined;
+
+  try {
+    initialData = await getCircuits({ page: 1, limit: 20 });
+  } catch (error) {
+    console.error("Error fetching circuits:", error);
+    initialData = emptyPaginatedResponse<ICircuit>(1, 20);
+    serverError =
+      "Failed to load circuits. Check your internet connection and try again.";
+  }
+
+  try {
+    coordinates = await getCircuitCoordinates();
+  } catch (error) {
+    console.error("Error fetching circuit coordinates:", error);
+    coordinates = [];
+  }
 
   let description = `Explore our database of ${initialData.meta.totalItems} karting circuits.`;
 
@@ -57,7 +76,11 @@ export default async function CircuitsPage() {
   return (
     <PageWrapper>
       <PageHeader title="Circuits" description={description} />
-      <CircuitsClient initialData={initialData} coordinates={coordinates} />
+      <CircuitsClient
+        initialData={initialData}
+        coordinates={coordinates}
+        serverError={serverError}
+      />
     </PageWrapper>
   );
 }

--- a/kartiiing/components/shared/ErrorState.tsx
+++ b/kartiiing/components/shared/ErrorState.tsx
@@ -6,8 +6,8 @@ type Props = {
 export function ErrorState({ message, title }: Props) {
   return (
     <div className="mx-auto px-4 py-8">
-      {title && <h1 className="text-2xl font-bold mb-4">{title}</h1>}
-      <div className="text-center py-10">
+      {title && <h1 className="text-2xl font-bold text-center">{title}</h1>}
+      <div className="text-center mt-4">
         <p className="text-muted-foreground">{message}</p>
       </div>
     </div>

--- a/kartiiing/lib/api/base.ts
+++ b/kartiiing/lib/api/base.ts
@@ -1,7 +1,37 @@
+const FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Get the base URL for API requests
  */
 export function getApiBase(): string {
   const base = process.env.NEXT_PUBLIC_API_URL || "/api";
   return base.replace(/\/$/, "");
+}
+
+/**
+ * Wrapper around fetch with a timeout via AbortController.
+ * Throws on network error, HTTP !ok, or timeout.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  options?: RequestInit & { timeoutMs?: number },
+): Promise<Response> {
+  const { timeoutMs = FETCH_TIMEOUT_MS, ...fetchOptions } = options || {};
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal,
+    });
+    return res;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") {
+      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }

--- a/kartiiing/lib/api/circuits.ts
+++ b/kartiiing/lib/api/circuits.ts
@@ -5,7 +5,7 @@ import {
   ISeoData,
   CircuitsOrderPreset,
 } from "@kartiiing/shared";
-import { getApiBase } from "./base";
+import { getApiBase, fetchWithTimeout } from "./base";
 
 const MS_DAY = 1000 * 60 * 60 * 24;
 
@@ -38,7 +38,7 @@ export async function getCircuits(options?: {
   if (longitude != null) params.set("userLongitude", longitude.toString());
 
   const url = `${getApiBase()}/circuits?${params.toString()}`;
-  const res = await fetch(url, { next: { revalidate: MS_DAY } });
+  const res = await fetchWithTimeout(url, { next: { revalidate: MS_DAY } });
 
   if (!res.ok) {
     throw new Error(`Failed to fetch circuits: ${res.status}`);
@@ -58,7 +58,7 @@ export async function getCircuitCoordinates(
 
   const queryString = params.toString();
   const url = `${getApiBase()}/circuits/coordinates${queryString ? `?${queryString}` : ""}`;
-  const res = await fetch(url, { next: { revalidate: MS_DAY } });
+  const res = await fetchWithTimeout(url, { next: { revalidate: MS_DAY } });
 
   if (!res.ok) {
     throw new Error(`Failed to fetch circuit coordinates: ${res.status}`);
@@ -72,7 +72,7 @@ export async function getCircuitCoordinates(
  */
 export async function getCircuitById(id: number): Promise<ICircuit> {
   const url = `${getApiBase()}/circuits/${id}`;
-  const res = await fetch(url, { next: { revalidate: MS_DAY } });
+  const res = await fetchWithTimeout(url, { next: { revalidate: MS_DAY } });
 
   if (!res.ok) {
     throw new Error(`Failed to fetch circuit ${id}: ${res.status}`);
@@ -86,7 +86,7 @@ export async function getCircuitById(id: number): Promise<ICircuit> {
  */
 export async function getCircuitsMetadata(): Promise<ISeoData> {
   const url = `${getApiBase()}/circuits/metadata`;
-  const res = await fetch(url);
+  const res = await fetchWithTimeout(url);
 
   if (!res.ok) {
     throw new Error(`Failed to fetch circuits metadata: ${res.status}`);

--- a/kartiiing/lib/api/race-events.ts
+++ b/kartiiing/lib/api/race-events.ts
@@ -6,13 +6,13 @@ import {
   IPaginatedResponse,
   ISeoData,
 } from "@kartiiing/shared";
-import { getApiBase } from "./base";
+import { getApiBase, fetchWithTimeout } from "./base";
 
 /**
  * Fetch available years that have race events
  */
 export async function getAvailableYears(): Promise<number[]> {
-  const res = await fetch(`${getApiBase()}/race-events/years`);
+  const res = await fetchWithTimeout(`${getApiBase()}/race-events/years`);
 
   if (!res.ok) {
     throw new Error(`Failed to fetch available years: ${res.status}`);
@@ -32,7 +32,7 @@ export async function getCalendarMetadata(year: string): Promise<ISeoData> {
       ? `${getApiBase()}/race-events/calendar-metadata`
       : `${getApiBase()}/race-events/calendar-metadata/${year}`;
 
-  const res = await fetch(endpoint);
+  const res = await fetchWithTimeout(endpoint);
 
   if (!res.ok) {
     throw new Error(`Failed to fetch calendar metadata: ${res.status}`);
@@ -66,7 +66,7 @@ export async function getRaceEvents(options?: {
     url += `&search=${encodeURIComponent(search)}`;
   }
 
-  const res = await fetch(url);
+  const res = await fetchWithTimeout(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch races: ${res.status}`);
   }
@@ -79,7 +79,7 @@ export async function getRaceEvents(options?: {
  */
 export async function getRaceEventById(id: number): Promise<IRaceEventDetail> {
   const url = `${getApiBase()}/race-events/by-id/${id}`;
-  const res = await fetch(url);
+  const res = await fetchWithTimeout(url);
 
   if (!res.ok) {
     throw new Error(`Failed to fetch race event: ${res.status}`);
@@ -94,7 +94,7 @@ export async function getRaceEventById(id: number): Promise<IRaceEventDetail> {
  */
 export async function getMinimalRaceEvents(): Promise<IRaceEventMinimal[]> {
   const url = `${getApiBase()}/race-events/minimal`;
-  const res = await fetch(url);
+  const res = await fetchWithTimeout(url);
 
   if (!res.ok) {
     throw new Error(`Failed to fetch minimal race events: ${res.status}`);

--- a/shared/src/types/pagination.types.ts
+++ b/shared/src/types/pagination.types.ts
@@ -11,3 +11,24 @@ export interface IPaginatedResponse<T> {
   data: T[];
   meta: IPaginationMeta;
 }
+
+/**
+ * Factory for an empty paginated response, used when there are no results
+ * or when the API is unreachable and a fallback response is needed.
+ */
+export function emptyPaginatedResponse<T>(
+  page: number = 1,
+  limit: number = 20,
+): IPaginatedResponse<T> {
+  return {
+    data: [],
+    meta: {
+      currentPage: page,
+      itemsPerPage: limit,
+      totalItems: 0,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+  };
+}


### PR DESCRIPTION
- fix: handle missing race events with empty response and error state
- Return empty paginated response from race events service instead of throwing a 404 error when no events are found.
- Add error state UI and catch client-side fetch errors in the calendar client component.
- Gracefully handle errors when fetching available years on the calendar page, preventing the page from crashing.